### PR TITLE
Add msgspec hooks for CrockfordUUID

### DIFF
--- a/pycrockford_msgspec/__init__.py
+++ b/pycrockford_msgspec/__init__.py
@@ -1,0 +1,17 @@
+# pyright: reportMissingImports=false, reportAttributeAccessIssue=false
+from __future__ import annotations
+
+from _pycrockford_rs_bindings import (
+    CrockfordUUID,
+    decode_crockford,
+    encode_crockford,
+)
+from .hooks import cuuid_decoder, cuuid_encoder
+
+__all__ = [
+    "CrockfordUUID",
+    "decode_crockford",
+    "encode_crockford",
+    "cuuid_decoder",
+    "cuuid_encoder",
+]

--- a/pycrockford_msgspec/hooks.py
+++ b/pycrockford_msgspec/hooks.py
@@ -19,11 +19,11 @@ def cuuid_decoder(type_hint: Type[Any], obj: Any) -> CrockfordUUID:
         raise msgspec.ValidationError(
             f"Expected str for CrockfordUUID, got {type(obj).__name__}"
         )
-    raise NotImplementedError(f"No decoder for type {type_hint}")
+    return NotImplemented
 
 
 def cuuid_encoder(obj: Any) -> str:
     """Encode CrockfordUUID instances for msgspec."""
     if isinstance(obj, CrockfordUUID):
         return str(obj)
-    raise TypeError(f"Cannot encode type {type(obj).__name__} as CrockfordUUID string")
+    return NotImplemented

--- a/pycrockford_msgspec/hooks.py
+++ b/pycrockford_msgspec/hooks.py
@@ -1,0 +1,29 @@
+# pyright: reportMissingImports=false, reportAttributeAccessIssue=false
+from __future__ import annotations
+
+from typing import Any, Type
+
+import msgspec
+
+from _pycrockford_rs_bindings import CrockfordUUID
+
+
+def cuuid_decoder(type_hint: Type[Any], obj: Any) -> CrockfordUUID:
+    """Decode CrockfordUUID strings for msgspec."""
+    if type_hint is CrockfordUUID:
+        if isinstance(obj, str):
+            try:
+                return CrockfordUUID(obj)
+            except Exception as exc:  # PyO3 raises PyValueError
+                raise msgspec.ValidationError(str(exc)) from exc
+        raise msgspec.ValidationError(
+            f"Expected str for CrockfordUUID, got {type(obj).__name__}"
+        )
+    raise NotImplementedError(f"No decoder for type {type_hint}")
+
+
+def cuuid_encoder(obj: Any) -> str:
+    """Encode CrockfordUUID instances for msgspec."""
+    if isinstance(obj, CrockfordUUID):
+        return str(obj)
+    raise TypeError(f"Cannot encode type {type(obj).__name__} as CrockfordUUID string")

--- a/pycrockford_msgspec/hooks.py
+++ b/pycrockford_msgspec/hooks.py
@@ -1,20 +1,29 @@
 # pyright: reportMissingImports=false, reportAttributeAccessIssue=false
 from __future__ import annotations
 
-from typing import Any, Type
+from typing import Any, get_args, get_origin, Union
+from types import NotImplementedType, UnionType
 
 import msgspec
 
 from _pycrockford_rs_bindings import CrockfordUUID
 
 
-def cuuid_decoder(type_hint: Type[Any], obj: Any) -> CrockfordUUID:
+def cuuid_decoder(type_hint: Any, obj: Any) -> CrockfordUUID | NotImplementedType:
     """Decode CrockfordUUID strings for msgspec."""
-    if type_hint is CrockfordUUID:
+    origin = get_origin(type_hint)
+    args = get_args(type_hint)
+    is_crockford_type = type_hint is CrockfordUUID or (
+        origin in (Union, UnionType) and CrockfordUUID in args
+    )
+
+    if is_crockford_type:
+        if obj is None:
+            return NotImplemented
         if isinstance(obj, str):
             try:
                 return CrockfordUUID(obj)
-            except Exception as exc:  # PyO3 raises PyValueError
+            except ValueError as exc:  # PyO3 raises PyValueError
                 raise msgspec.ValidationError(str(exc)) from exc
         raise msgspec.ValidationError(
             f"Expected str for CrockfordUUID, got {type(obj).__name__}"
@@ -22,8 +31,6 @@ def cuuid_decoder(type_hint: Type[Any], obj: Any) -> CrockfordUUID:
     return NotImplemented
 
 
-def cuuid_encoder(obj: Any) -> str:
+def cuuid_encoder(obj: Any) -> str | NotImplementedType:
     """Encode CrockfordUUID instances for msgspec."""
-    if isinstance(obj, CrockfordUUID):
-        return str(obj)
-    return NotImplemented
+    return str(obj) if isinstance(obj, CrockfordUUID) else NotImplemented

--- a/pycrockford_msgspec/unittests/test_hooks.py
+++ b/pycrockford_msgspec/unittests/test_hooks.py
@@ -29,3 +29,10 @@ def test_invalid_decode_raises() -> None:
 def test_hooks_return_not_implemented() -> None:
     assert cuuid_decoder(str, "abc") is NotImplemented
     assert cuuid_encoder("abc") is NotImplemented
+
+
+def test_decoder_optional_handling() -> None:
+    hint = CrockfordUUID | None
+    uuid_obj = CrockfordUUID.generate_v4()
+    assert cuuid_decoder(hint, None) is NotImplemented
+    assert cuuid_decoder(hint, str(uuid_obj)) == uuid_obj

--- a/pycrockford_msgspec/unittests/test_hooks.py
+++ b/pycrockford_msgspec/unittests/test_hooks.py
@@ -24,3 +24,8 @@ def test_invalid_decode_raises() -> None:
     bad_json = b'{"id":"not-a-cuuid","name":"x"}'
     with pytest.raises(msgspec.ValidationError):
         decoder.decode(bad_json)
+
+
+def test_hooks_return_not_implemented() -> None:
+    assert cuuid_decoder(str, "abc") is NotImplemented
+    assert cuuid_encoder("abc") is NotImplemented

--- a/pycrockford_msgspec/unittests/test_hooks.py
+++ b/pycrockford_msgspec/unittests/test_hooks.py
@@ -1,0 +1,26 @@
+# pyright: reportMissingImports=false, reportAttributeAccessIssue=false
+from __future__ import annotations
+
+import msgspec
+import pytest
+
+from pycrockford_msgspec import CrockfordUUID, cuuid_decoder, cuuid_encoder
+
+
+class Sample(msgspec.Struct):
+    id: CrockfordUUID
+    name: str
+
+
+def test_encode_decode_round_trip() -> None:
+    original = Sample(id=CrockfordUUID.generate_v4(), name="example")
+    encoded = msgspec.json.Encoder(enc_hook=cuuid_encoder).encode(original)
+    decoded = msgspec.json.Decoder(type=Sample, dec_hook=cuuid_decoder).decode(encoded)
+    assert decoded == original
+
+
+def test_invalid_decode_raises() -> None:
+    decoder = msgspec.json.Decoder(type=Sample, dec_hook=cuuid_decoder)
+    bad_json = b'{"id":"not-a-cuuid","name":"x"}'
+    with pytest.raises(msgspec.ValidationError):
+        decoder.decode(bad_json)


### PR DESCRIPTION
## Summary
- expose Rust bindings via new Python package
- implement `cuuid_encoder` and `cuuid_decoder` for msgspec
- test msgspec round-trip with the new hooks

## Testing
- `ruff format pycrockford_msgspec/hooks.py pycrockford_msgspec/__init__.py pycrockford_msgspec/unittests/test_hooks.py`
- `ruff check pycrockford_msgspec/hooks.py pycrockford_msgspec/__init__.py pycrockford_msgspec/unittests/test_hooks.py`
- `pyright pycrockford_msgspec/hooks.py pycrockford_msgspec/__init__.py pycrockford_msgspec/unittests/test_hooks.py`
- `cargo fmt --manifest-path pycrockford_rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path pycrockford_rs/Cargo.toml -- -D warnings`
- `cargo test --manifest-path pycrockford_rs/Cargo.toml`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476f405a2c8322a0f71fbbc575adf0

## Summary by Sourcery

Introduce the pycrockford_msgspec package to expose Rust CrockfordUUID bindings in Python and add msgspec encoder/decoder hooks with validation.

New Features:
- Expose CrockfordUUID and its encode/decode bindings via a new Python package
- Implement cuuid_encoder and cuuid_decoder hooks for msgspec to handle CrockfordUUID objects

Tests:
- Add unit tests for msgspec hooks covering round-trip encoding/decoding, invalid input errors, non-applicable types returning NotImplemented, and optional UUID handling